### PR TITLE
added Updrage Header to solve an Web socket updgrade issue on Apache2

### DIFF
--- a/docs/apache.md
+++ b/docs/apache.md
@@ -7,6 +7,7 @@ Here are configuration examples for setting up apache as reverse proxy for gotif
 
 The following modules are required:
 
+- mod_rewrite
 - mod_proxy
 - mod_proxy_wstunnel
 - mod_proxy_http
@@ -47,6 +48,9 @@ The following modules are required:
     ProxyPreserveHost On
 
     # Proxy web socket requests to /stream
+    RewriteEngine  on
+    RewriteCond %{HTTP:Upgrade} =websocket
+    RewriteRule /gotify/stream(.*) ws://127.0.0.1:GOTIFY_PORT/stream$1 [P,L]
     ProxyPass "/gotify/stream" ws://127.0.0.1:GOTIFY_PORT/stream retry=0 timeout=5
 
     # Proxy all other requests to /

--- a/docs/apache.md
+++ b/docs/apache.md
@@ -7,7 +7,6 @@ Here are configuration examples for setting up apache as reverse proxy for gotif
 
 The following modules are required:
 
-- mod_rewrite
 - mod_proxy
 - mod_proxy_wstunnel
 - mod_proxy_http
@@ -48,9 +47,6 @@ The following modules are required:
     ProxyPreserveHost On
 
     # Proxy web socket requests to /stream
-    RewriteEngine  on
-    RewriteCond %{HTTP:Upgrade} =websocket
-    RewriteRule /gotify/stream(.*) ws://127.0.0.1:GOTIFY_PORT/stream$1 [P,L]
     ProxyPass "/gotify/stream" ws://127.0.0.1:GOTIFY_PORT/stream retry=0 timeout=5
 
     # Proxy all other requests to /
@@ -59,4 +55,12 @@ The following modules are required:
 
     ProxyPassReverse /gotify/ http://127.0.0.1:GOTIFY_PORT/
 </VirtualHost>
+```
+
+NOTE: In some configurations you can meet a WebSocket 400 error, to solve it please enable `mod_rewrite` and added 3 Rewrite Rules in a "Proxy web socket requests" section before first `ProxyPass`:
+
+```
+    RewriteEngine  on
+    RewriteCond %{HTTP:Upgrade} =websocket
+    RewriteRule /gotify/stream(.*) ws://127.0.0.1:GOTIFY_PORT/stream$1 [P,L]
 ```


### PR DESCRIPTION
This config causing Error as per https://github.com/gotify/server/issues/139, additional config from https://github.com/gotify/server/issues/23 needed.

From: https://stackoverflow.com/questions/53939609/apache-websocket-connectionupgrade-replaced-by-keep-alive
"Apache does not understand websockets in one sense (i.e. when it is talking to itself). As a result, you need to use mod_rewrite and set the protocol to ws:// in order to forward websockets upstream (it seems that no amount of setting headers will help you here)."