### PR TITLE
Refresh the first-login page

### DIFF
--- a/docs/first-login.md
+++ b/docs/first-login.md
@@ -3,6 +3,8 @@ id: first-login
 title: First Login
 ---
 
-After setting up gotify/server you can login to the WebUI.
+After setting up gotify/server you can login to the WebUI. When first launched an initial account is created so you can log in. If you have not overriden the defaults in the configuration, use username: `admin` password: `admin`.
 
-If you have not changed the default username and password in the configuration, use username: `admin` password: `admin`, but remember to change them in the WebUI for security.
+Once you have logged in you can create your own user(s) and, if desired, delete the default account (after creating a separate administrator account). You can also remove any username/password overrides in your configuration, as they are only used to initially create this account.
+
+If you choose to keep the default account be sure to change the password so it is not `admin`!


### PR DESCRIPTION
Notably to call out that the default user can be safely deleted. gotify/server#392 asks for support for secret configuration values, but this isn't really necessary for these values since they're only used on first launch.