### PR TITLE
update systemd (file -> append)

### DIFF
--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -27,8 +27,8 @@ Type=simple
 User=root
 WorkingDirectory=/opt/gotify
 ExecStart=/opt/gotify/gotify
-StandardOutput=file:/var/log/gotify/gotify.log
-StandardError=file:/var/log/gotify/gotify-error.log
+StandardOutput=append:/var/log/gotify/gotify.log
+StandardError=append:/var/log/gotify/gotify-error.log
 Restart=always
 RestartSec=3
 


### PR DESCRIPTION
The value `file` for `StandardOutput` and `StandardError` works differently than expected. The file is created and used only once - ever. This means that when the service is restarted, there won't be any logging anymore.
Using the keyword `append` will reuse the log file and is the correct way to specify logfiles in systemd.