### PR TITLE
Fix shell in optimize-images script

### DIFF
--- a/docs/optimize-images.md
+++ b/docs/optimize-images.md
@@ -25,7 +25,7 @@ Install
 Create a script, e.g. `/opt/gotify/optimize-images.sh` containing
 
 ```bash
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
 
 DATA=/home/jm/src/gotify/server/data

--- a/docs/optimize-images.md
+++ b/docs/optimize-images.md
@@ -32,7 +32,7 @@ DATA=/home/jm/src/gotify/server/data
 
 for FILE in "$DATA"/images/*; do
     if [ "$FILE" -nt "$DATA"/images-optimized ]; then
-        EXT=$(echo "${FILE#*.}"|tr '[:upper:]' '[:lower:]')
+        EXT=$(echo "${FILE##*.}"|tr '[:upper:]' '[:lower:]')
         if [ "$EXT" = png -o "$EXT" = jpg -o "$EXT" = jpeg  -o "$EXT" = gif ]; then
             convert "$FILE" -resize "512>" "$FILE"
         fi


### PR DESCRIPTION
I tried to run this script with the hashbang as it was and, at the very least in Ubuntu 24.04, `sh` resolves to `dash`, which causes the script to run without processing any images, creating just the `images-optimized` file, with no errors or output. Changing it to use `bash` made it work correctly.

My best guess is in the `if [ "$FILE" -nt "$DATA"/images-optimized ]`  check, which has a very subtle but important difference between bash and dash:

bash:
```
file1 -nt file2

True if file1 is newer (according to modification date) than file2, or if file1 exists and file2 does not.
```

dash:
```
file1 -nt file2

True if file1 and file2 exist and file1 is newer than file2.
```

Since `images-optimized` doesn't exist on the first run, that condition fails silently until the end of the first run in dash, and subsequent runs won't process old images, only new ones.

Regardless, changing this to bash should avoid more surprises like this in the future.

Alternatively, if you wish to keep it using dash, then it could be edited to take into account those differences, but the hashbang should probably be changed to specify dash, since sh can vary:

```sh
#!/usr/bin/env dash
(...)
    if [ ! -f "$DATA"/images-optimized ] || [ "$FILE" -nt "$DATA"/images-optimized ]; then
(...)
```